### PR TITLE
enabled Logger.log/trace/info/warn/error to work from Meteor client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .build*
+.npm

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Loggly.{warn, error, info, trace} will produce error message with appropriate ta
 ## Usage
 
 ```js
+      //Create the Logger object on the server side only
+      //for example, you can put the following in Meteor.startup on the server
 
       Logger = new Loggly({
         token: "your-really-long-input-token",
@@ -24,10 +26,12 @@ Loggly.{warn, error, info, trace} will produce error message with appropriate ta
         //
         // Optional: Tag to send with EVERY log message
         //
-        tags: ['global-tag'],
+        tags: ["global-tag"],
         // Optional: logs will be stored in JSON format
-        json: true
+        json: "true"
       });
+
+      //The following can be called on either the Meteor client or server
 
       Logger.log("first log from meteor");
       Logger.info("it will store this message with info tag");

--- a/logglyClient.js
+++ b/logglyClient.js
@@ -1,0 +1,21 @@
+Logger = {};
+
+Logger.log = function (param, tag) {
+  Meteor.call('logglyLog', param, tag, function() {});
+};
+
+Logger.trace = function (param, tag) {
+  Meteor.call('logglyTrace', param, tag, function() {});
+};
+
+Logger.info = function (param, tag) {
+  Meteor.call('logglyInfo', param, tag, function() {});
+};
+
+Logger.warn = function (param, tag) {
+  Meteor.call('logglyWarn', param, tag, function() {});
+};
+
+Logger.error = function (param, tag) {
+  Meteor.call('logglyError', param, tag, function() {});
+};

--- a/logglyMeteorMethods.js
+++ b/logglyMeteorMethods.js
@@ -1,0 +1,39 @@
+/***
+ * loggerSet - checks to see if the Logger object has been created on server
+ * @returns {boolean} - return true if the Logger object has been created on server
+ */
+var loggerSet = function () {
+  if (typeof Logger !== 'undefined' && Logger !== null) {
+    return true;
+  }
+  console.log('Logger object was not created on the Meteor Server');
+  return false;
+};
+
+Meteor.methods({
+  logglyLog: function(param, tag) {
+    if (loggerSet()){
+      Logger.log(param, tag);
+    }
+  },
+  logglyTrace: function(param, tag) {
+    if (loggerSet()){
+      Logger.trace(param, tag);
+    }
+  },
+  logglyInfo: function(param, tag) {
+    if (loggerSet()){
+      Logger.info(param, tag);
+    }
+  },
+  logglyWarn:  function(param, tag) {
+    if (loggerSet()){
+      Logger.warn(param, tag);
+    }
+  },
+  logglyError:  function(param, tag) {
+    if (loggerSet()) {
+      Logger.error(param, tag);
+    }
+  }
+});

--- a/logglyServer.js
+++ b/logglyServer.js
@@ -9,7 +9,7 @@ Loggly = function(options) {
  */
 Loggly.prototype.log = function (param, tag) {
   this.client.log(param, tag);
-}
+};
 
 /**
  * Set of useful methods to log with the tag
@@ -18,29 +18,25 @@ Loggly.prototype.log = function (param, tag) {
  */
 
 Loggly.prototype._applyArguments = function (args, tag) {
-  if (args && args.length == 1) {
+  if (args && args.length === 1) {
     this.client.log(args[0], tag);
   } else {
     this.client.log(args, tag);
   }
-}
+};
 
 Loggly.prototype.trace = function () {
   this._applyArguments(arguments, 'trace');
-}
+};
 
 Loggly.prototype.info = function () {
   this._applyArguments(arguments, 'info');
-}
+};
 
 Loggly.prototype.warn = function () {
   this._applyArguments(arguments, 'warn');
-}
+};
 
 Loggly.prototype.error = function () {
   this._applyArguments(arguments, 'error');
-}
-
-
-
-
+};

--- a/package.js
+++ b/package.js
@@ -1,15 +1,21 @@
 Package.describe({
-  summary: 'Loggly client for Meteor',
-  version: '0.2.0'
+  name: 'avrora:loggly',
+  summary: 'Loggly for Meteor',
+  version: '0.3.0',
+  git: 'https://github.com/avrora/loggly/'
 });
 
 Npm.depends({
-  "loggly": "1.0.4"
+  'loggly': '1.0.8'
 });
 
-Package.on_use(function (api, where) {
-  api.add_files('loggly.js', 'server');
-  api.export("Loggly", "server");
+Package.onUse(function (api) {
+  api.versionsFrom('0.9.4');
+  api.addFiles('logglyServer.js', 'server');
+  api.addFiles('logglyMeteorMethods.js', 'server');
+  api.addFiles('logglyClient.js', 'client');
+  api.export('Loggly', 'server');
+  api.export('Logger', 'client'); //Logger Object needs to be created on server side
 });
 
 


### PR DESCRIPTION
Currently the loggly package provide support only for Meteor server.  There was a request for client side logging (https://github.com/avrora/loggly/issues/1), so I created this change.  Basically, we are using meteor methods to transfer Logger calls from the client to the server.  The server then passes the messages to Loggly.  

The client side uses Logger.log/info/warn/trace/error in the same manner as the server.  
