### PR TITLE
Handling undefined server-side Logger 

### DIFF
--- a/logglyMeteorMethods.js
+++ b/logglyMeteorMethods.js
@@ -1,54 +1,32 @@
-/***
- * loggerSet - checks to see if the Logger object has been created on server
- * @returns {boolean} - return true if the Logger object has been created on server
- */
-var loggerSet = function () {
-  if (typeof Logger !== 'undefined' && Logger !== null) {
-    return true;
-  }
-  console.log('Logger object was not created on the Meteor Server');
-  return false;
-};
-
 Meteor.methods({
   logglyLog: function(param, tag) {
     check(param,Object);
     check(tag,Match.OneOf([String],null));
 
-    if (loggerSet()){
-      Logger.log(param, tag);
-    }
+    Logger.log(param, tag);
   },
   logglyTrace: function(param, tag) {
     check(param,Object);
     check(tag,Match.OneOf([String],null));
 
-    if (loggerSet()){
-      Logger.trace(param, tag);
-    }
+    Logger.trace(param, tag);
   },
   logglyInfo: function(param, tag) {
     check(param,Object);
     check(tag,Match.OneOf([String],null));
 
-    if (loggerSet()){
-      Logger.info(param, tag);
-    }
+    Logger.info(param, tag);
   },
   logglyWarn:  function(param, tag) {
     check(param,Object);
     check(tag,Match.OneOf([String],null));
 
-    if (loggerSet()){
-      Logger.warn(param, tag);
-    }
+    Logger.warn(param, tag);
   },
   logglyError:  function(param, tag) {
     check(param,Object);
     check(tag,Match.OneOf([String],null));
 
-    if (loggerSet()) {
-      Logger.error(param, tag);
-    }
+    Logger.error(param, tag);
   }
 });

--- a/logglyServer.js
+++ b/logglyServer.js
@@ -40,3 +40,28 @@ Loggly.prototype.warn = function () {
 Loggly.prototype.error = function () {
   this._applyArguments(arguments, 'error');
 };
+
+// Create a default Logger object. Normally, this gets overwritten with the 'real'
+// Logger. The purpose of this default Logger is preventing errors from being thrown
+// on the server if there's no Logger created.
+Logger = {};
+
+Logger.log = function () {
+  console.log('Logger object was not created on the Meteor Server');
+};
+
+Logger.trace = function () {
+  console.log('Logger object was not created on the Meteor Server');
+};
+
+Logger.info = function () {
+  console.log('Logger object was not created on the Meteor Server');
+};
+
+Logger.warn = function () {
+  console.log('Logger object was not created on the Meteor Server');
+};
+
+Logger.error = function () {
+  console.log('Logger object was not created on the Meteor Server');
+};

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'miktam:loggly',
   summary: 'Loggly for Meteor',
-  version: '1.1.0',
+  version: '1.1.1',
   git: 'https://github.com/miktam/loggly/'
 });
 
@@ -15,8 +15,6 @@ Package.onUse(function (api) {
   api.addFiles('logglyMeteorMethods.js', 'server');
   api.addFiles('logglyClient.js', 'client');
   api.export('Loggly', 'server');
-  api.export('Logger', 'client'); //Logger Object needs to be created on server side
+  api.export('Logger', 'client');
+  api.export('Logger', 'server'); // Normally overwritten by users but handles cases of undefined Loggers on the server.
 });
-
-
-


### PR DESCRIPTION
Added a mock Logger on the server. The mock Logger is normally over-written by any Logger object created in a Meteor.startup() method. Previously, undefined Loggers were only handled for client-side calls but server-side logging attempts would throw errors.
